### PR TITLE
Add options to reverse scroll direction when inserting items with mouse wheel

### DIFF
--- a/src/main/java/codechicken/nei/NEIClientConfig.java
+++ b/src/main/java/codechicken/nei/NEIClientConfig.java
@@ -132,6 +132,9 @@ public class NEIClientConfig {
 
         tag.getTag("inventory.profileRecipes").getBooleanValue(false);
         API.addOption(new OptionToggleButton("inventory.profileRecipes", true));
+		
+		tag.getTag("inventory.reversedMouseScroll").getBooleanValue(true);
+		API.addOption(new OptionToggleButton("inventory.reversedMouseScroll", true));
 
         tag.getTag("command.creative").setDefaultValue("/gamemode {0} {1}");
         API.addOption(new OptionTextField("command.creative"));
@@ -356,7 +359,16 @@ public class NEIClientConfig {
             world.saveNBT();
         }
     }
-
+	
+	/**
+	 * Gets user setting for how should be handled item insertion/extraction with the mousewheel
+	 *
+	 * @return If reversedMouseScroll is true;
+	 */
+	public static boolean isScrollInsertReversed() {
+		return getBooleanSetting("inventory.reversedMouseScroll");
+	}
+	
     /**
      * Gets whether MagnetMode is enabled or not.
      *

--- a/src/main/java/codechicken/nei/NEIController.java
+++ b/src/main/java/codechicken/nei/NEIController.java
@@ -113,6 +113,10 @@ public class NEIController implements IInputHandler {
             Point mousePos = getMousePosition();
             Slot mouseover = container.getSlotAtPosition(mousePos.x, mousePos.y);
             if (mouseover != null && mouseover.getHasStack() && !ItemInfo.fastTransferContainerExemptions.contains(container.getClass())) {
+				if (!NEIClientConfig.isScrollInsertReversed()) {
+					scrolled = -scrolled;
+				}
+				
                 if (scrolled > 0) {
                     fastTransferManager.transferItem(container, mouseover.slotNumber);
                 } else {


### PR DESCRIPTION
Adds config option under inventory to reverse scroll direction when inserting/extracting with mousewheel
add a check to said option to reverse or not the insertion by reversing the scroll direction.